### PR TITLE
バリデーションをぽちぽちと設定していく

### DIFF
--- a/lib/kirico/models/changing_address_record.rb
+++ b/lib/kirico/models/changing_address_record.rb
@@ -36,12 +36,12 @@ module Kirico
     validates :zip_code1, charset: { accept: [:numeric] }, sjis_bytesize: { is: 3 }
     validates :zip_code2, charset: { accept: [:numeric] }, sjis_bytesize: { is: 4 }
     validates :new_address_yomi, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..75 }
-    validates :new_address, charset: { accept: [:kanji] }, sjis_bytesize: { in: 0..74 }
+    validates :new_address, charset: { accept: [:all] }, sjis_bytesize: { in: 0..74 }, allow_blank: true
     validates :ip_name_yomi, charset: { accept: [:katakana] }, sjis_bytesize: { in: 1..25 }
-    validates :ip_name, charset: { accept: [:kanji] }, sjis_bytesize: { in: 0..24 }
+    validates :ip_name, charset: { accept: [:all] }, sjis_bytesize: { in: 0..24 }, allow_blank: true
     validates :old_address_yomi, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..75 }
-    validates :old_address, charset: { accept: [:kanji] }, sjis_bytesize: { in: 0..74 }
-    validates :memo, charset: { accept: [:all] }, sjis_bytesize: { in: 0..75 }
+    validates :old_address, charset: { accept: [:all] }, sjis_bytesize: { in: 0..74 }, allow_blank: true
+    validates :memo, charset: { accept: [:all] }, sjis_bytesize: { in: 0..75 }, allow_blank: true
 
     define_format_date_method :birth_at, :updated_at
     define_code_mapper_method :birth_at_era_nengo, :updated_at_era_nengo

--- a/lib/kirico/models/changing_address_record.rb
+++ b/lib/kirico/models/changing_address_record.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 require 'virtus'
+require 'active_model'
 require 'kirico/models/helper'
 
 module Kirico
   class ChangingAddressRecord
     include Virtus.model
+    include ActiveModel::Validations
     extend Kirico::Helper
 
     DOC_CODE = '22187041'
@@ -25,6 +27,21 @@ module Kirico
     attribute :old_address_yomi, String
     attribute :old_address, String
     attribute :memo, String
+
+    validates :area_code, charset: { accept: [:numeric] }, sjis_bytesize: { is: 2 }
+    validates :office_code, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..4 }
+    validates :ip_code, charset: { accept: [:numeric] }, sjis_bytesize: { in: 1..6 }
+    validates :basic_pension_number1, charset: { accept: [:numeric] }, sjis_bytesize: { is: 4 }, allow_blank: true
+    validates :basic_pension_number2, charset: { accept: [:numeric] }, sjis_bytesize: { is: 6 }, allow_blank: true
+    validates :zip_code1, charset: { accept: [:numeric] }, sjis_bytesize: { is: 3 }
+    validates :zip_code2, charset: { accept: [:numeric] }, sjis_bytesize: { is: 4 }
+    validates :new_address_yomi, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..75 }
+    validates :new_address, charset: { accept: [:kanji] }, sjis_bytesize: { in: 0..74 }
+    validates :ip_name_yomi, charset: { accept: [:katakana] }, sjis_bytesize: { in: 1..25 }
+    validates :ip_name, charset: { accept: [:kanji] }, sjis_bytesize: { in: 0..24 }
+    validates :old_address_yomi, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..75 }
+    validates :old_address, charset: { accept: [:kanji] }, sjis_bytesize: { in: 0..74 }
+    validates :memo, charset: { accept: [:all] }, sjis_bytesize: { in: 0..75 }
 
     define_format_date_method :birth_at, :updated_at
     define_code_mapper_method :birth_at_era_nengo, :updated_at_era_nengo

--- a/lib/kirico/models/company.rb
+++ b/lib/kirico/models/company.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 require 'virtus'
+require 'active_model'
 
 module Kirico
   class Company
     include Virtus.model
+    include ActiveModel::Validations
 
     attribute :area_code, String
     attribute :office_code, String
@@ -14,6 +16,16 @@ module Kirico
     attribute :name, String
     attribute :owner_name, String
     attribute :tel_number, String
+
+    validates :area_code, charset: { accept: [:numeric] }, sjis_bytesize: { is: 2 }
+    validates :office_code, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..4 }
+    validates :office_number, charset: { accept: [:numeric] }, sjis_bytesize: { in: 1..5 }
+    validates :zip_code1, charset: { accept: [:numeric] }, sjis_bytesize: { is: 3 }
+    validates :zip_code2, charset: { accept: [:numeric] }, sjis_bytesize: { is: 4 }
+    validates :address, charset: { accept: [:all] }, sjis_bytesize: { in: 1..75 }
+    validates :name, charset: { accept: [:katakana, :kanji] }, sjis_bytesize: { in: 1..50 }
+    validates :owner_name, charset: { accept: [:katakana, :kanji] }, sjis_bytesize: { in: 1..25 }
+    validates :tel_number, charset: { accept: [:latin, :number] }, sjis_bytesize: { in: 1..12 }
 
     def initialize
       yield(self) if block_given?

--- a/lib/kirico/models/fd_management_record.rb
+++ b/lib/kirico/models/fd_management_record.rb
@@ -17,6 +17,8 @@ module Kirico
     attribute :created_at, Date
 
     validates :area_code, charset: { accept: [:numeric] }, sjis_bytesize: { is: 2 }
+    validates :office_code, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..4 }
+    validates :fd_seq_number, charset: { accept: [:numeric] }, sjis_bytesize: { is: 3 }
 
     define_format_date_method :created_at
 

--- a/lib/kirico/validators/sjis_bytesize_validator.rb
+++ b/lib/kirico/validators/sjis_bytesize_validator.rb
@@ -47,7 +47,7 @@ module Kirico
     end
 
     def validate_each(record, attribute, value = '')
-      value_length = value.encode('Shift_JIS').bytesize
+      value_length = value.to_s.encode('Shift_JIS').bytesize
 
       errors_options = options.except(*RESERVED_OPTIONS)
 

--- a/spec/kirico/validators/sjis_bytesize_validator_spec.rb
+++ b/spec/kirico/validators/sjis_bytesize_validator_spec.rb
@@ -47,6 +47,12 @@ describe Kirico::SjisBytesizeValidator do
     end
   end
 
+  context 'when the string is nil' do
+    it 'should be invlaid' do
+      expect(SjisBytesizeTestIs3.new(my_field: nil)).not_to be_valid
+    end
+  end
+
   context 'when the string is NOT in Shift_JIS' do
     it 'raises exception' do
       expect {


### PR DESCRIPTION
## やりたいこと

#2 で作成したバリデータをポチポチと設定しました。

## やったこと

バリデーションを設定しました。

対象は...

- FD 管理レコード（P. 27~）
- 事業所情報（p. 34~）
- 住所変更届データレコード（p. 63~）

※カッコ内は仕様書のページ

## やらなかったこと

相関チェックはまだ

## 確認方法

```ruby
# kirico 直下で bundle exec pry
require 'kirico'
require 'factory_girl'
FactoryGirl.find_definitions

rec = FactoryGirl.build(:changing_address_record)
rec.valid? # => true

rec.old_address_yomi = '全角はNGです'
rec.valid? # => false
rec.errors # => 略

rec.ip_code = '9999999999'
rec.valid? # => false
rec.errors # => 略
```

## 関連リンク

- 仕様書: [年金事務所への届出用（14\.00版）（PDF　43,699KB）](https://www.nenkin.go.jp/denshibenri/setsumei/20150415.files/0000024647OI4DNYrmWE.pdf)
- [論物辞書
](https://docs.google.com/spreadsheets/d/1MmXDA_IQyNmA_ptZqbKRWxSLId03uwDS6P-3GcsifcM/edit#gid=0)