### PR TITLE
相関バリデーションの実装

### DIFF
--- a/kirico.gemspec
+++ b/kirico.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'activemodel'
   spec.add_dependency 'era_ja'
+  spec.add_dependency 'validates_timeliness'
   spec.add_dependency 'virtus'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/lib/kirico/config/locales/en.yml
+++ b/lib/kirico/config/locales/en.yml
@@ -2,3 +2,11 @@ en:
   errors:
     messages:
       invalid_charset: "has invalid character(s): %{error_chars}"
+      invalid_date: "is not a valid date"
+      invalid_time: "is not a valid time"
+      invalid_datetime: "is not a valid datetime"
+      is_at: "must be at %{restriction}"
+      before: "must be before %{restriction}"
+      on_or_before: "must be on or before %{restriction}"
+      after: "must be after %{restriction}"
+      on_or_after: "must be on or after %{restriction}"

--- a/lib/kirico/config/locales/ja.yml
+++ b/lib/kirico/config/locales/ja.yml
@@ -5,3 +5,55 @@ ja:
       too_long: は%{count}文字以内で入力してください。
       too_short: は%{count}文字以上で入力してください。
       wrong_length: は%{count}文字で入力してください。
+      invalid_date: "は正しい形式で入力してください。"
+      invalid_time: "は正しい形式で入力してください。"
+      invalid_datetime: "は正しい形式で入力してください。"
+      is_at: "は %{restriction} である必要があります。"
+      before: "は %{restriction} より前を指定してください。"
+      on_or_before: "は %{restriction} 以前を指定してください。"
+      after: "は %{restriction} より後を指定してください。"
+      on_or_after: "は %{restriction} 以降を指定してください。"
+  activemodel:
+    models:
+      kirico/changing_address_record: 住所変更データレコード
+      kirico/company_count: 事業所数情報
+      kirico/company_identifier: 事業所識別符号
+      kirico/company: 事業所情報
+      kirico/data_identifier: データ識別符号
+      kirico/fd_management_record: FD管理レコード
+    attributes:
+      kirico/changing_address_record:
+        area_code: 都市区符号
+        office_code: 事業所記号
+        ip_code: 被保険者整理番号
+        basic_pension_number1: 基礎年金番号（課所符号）
+        basic_pension_number2: 基礎年金番号（一連番号）
+        birth_at: 生年月日
+        zip_code1: 郵便番号（親番号）
+        zip_code2: 郵便番号（子番号）
+        new_address_yomi: 変更後被保険者住所（カナ）
+        new_address: 変更後被保険者住所（漢字）
+        updated_at: 変更年月日
+        ip_name_yomi: 被保険者氏名（カナ）
+        ip_name: 被保険者氏名（漢字）
+        old_address_yomi: 変更前被保険者住所（カナ）
+        old_address: 変更前被保険者住所（漢字）
+        memo: 備考欄
+      kirico/company:
+        sr_name: 社会保険労務士氏名
+        count: 事業所数情報
+        area_code: 都市区符号
+        office_code: 事業所記号
+        office_number: 事業所番号
+        zip_code1: 郵便番号.親番号
+        zip_code2: 郵便番号.子番号
+        address: 事業所所在地
+        name: 事業所名称
+        owner_name: 事業主氏名
+        tel_number: 電話番号
+      kirico/fd_management_record:
+        area_code: 都市区符号
+        office_code: 事業所記号
+        fd_seq_number: FD通番
+        created_at: 作成年月日
+        main_doc_code: 代表届書コード

--- a/lib/kirico/models/changing_address_record.rb
+++ b/lib/kirico/models/changing_address_record.rb
@@ -2,6 +2,7 @@
 require 'virtus'
 require 'active_model'
 require 'kirico/models/helper'
+require 'validates_timeliness'
 
 module Kirico
   class ChangingAddressRecord
@@ -37,6 +38,7 @@ module Kirico
     validates :zip_code2, charset: { accept: [:numeric] }, sjis_bytesize: { is: 4 }
     validates :new_address_yomi, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..75 }
     validates :new_address, charset: { accept: [:all] }, sjis_bytesize: { in: 0..74 }, allow_blank: true
+    validates :updated_at, timeliness: { on_or_before: :today, type: :date }
     validates :ip_name_yomi, charset: { accept: [:katakana] }, sjis_bytesize: { in: 1..25 }
     validates :ip_name, charset: { accept: [:all] }, sjis_bytesize: { in: 0..24 }, allow_blank: true
     validates :old_address_yomi, charset: { accept: [:numeric, :latin, :katakana] }, sjis_bytesize: { in: 1..75 }


### PR DESCRIPTION
after #3 

## やりたいこと

相関バリデーションの必要な個所に設定したかった。

## やったこと

- 相関バリデーションを設定した（1 項目しか無かった...）
- （ついでに）i18n

## やらなかったこと

レコードをまたいだバリデーションも有り得るが、一旦保留。
現在分かっているのは「都市区符号」「事業所記号」のみ、これらはレコードをまたいで同じである必要がある
これらを束ねる親モデルがあってもよいのかも・・・？

## 確認方法

```ruby
# kirico 直下で bundle exec pry
require 'kirico'
require 'factory_girl'
FactoryGirl.find_definitions

require 'i18n'
I18n.locale = :ja

rec = FactoryGirl.build(:changing_address_record)
rec.valid? # => true

rec.updated_at = Date.today
rec.valid? # => true

rec.updated_at = Date.today + 1.day
rec.valid?
rec.errors # => 略
rec.errors.full_messages # => 略
```

## 関連リンク

- #3 
- [設計メモ 〜 CSV 形式届書作成モジュール · kufu/hanica Wiki](https://github.com/kufu/hanica/wiki/%E8%A8%AD%E8%A8%88%E3%83%A1%E3%83%A2-%E3%80%9C-CSV-%E5%BD%A2%E5%BC%8F%E5%B1%8A%E6%9B%B8%E4%BD%9C%E6%88%90%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB)
- [kirico 論物辞書 \- Google スプレッドシート](https://docs.google.com/spreadsheets/d/1MmXDA_IQyNmA_ptZqbKRWxSLId03uwDS6P-3GcsifcM/edit#gid=0)
 

## キャプチャ

:sushi:

## 新しいStyleGuide

:sushi:

## マージ後にやること

:sushi:
