### PR TITLE
正規表現において特別な意味を持つ文字を指定した場合に例外となる問題の改修

### DIFF
--- a/lib/kirico/validators/charset_validator.rb
+++ b/lib/kirico/validators/charset_validator.rb
@@ -75,11 +75,11 @@ module Kirico
 
       ch = match.captures[0].encode('UTF-8')
       error_chars << ch
-      retrieve_error_chars(value.gsub(/#{ch}/, ''), error_chars)
+      retrieve_error_chars(value.gsub(/#{Regexp.escape(ch)}/, ''), error_chars)
     rescue Encoding::UndefinedConversionError => e
       ch = e.error_char
       error_chars << ch
-      retrieve_error_chars(value.gsub(/#{ch}/, ''), error_chars)
+      retrieve_error_chars(value.gsub(/#{Regexp.escape(ch)}/, ''), error_chars)
     end
 
     private

--- a/lib/kirico/version.rb
+++ b/lib/kirico/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Kirico
-  VERSION = '0.1.7'
+  VERSION = '0.1.8'
 end

--- a/spec/kirico/validators/charset_validator_spec.rb
+++ b/spec/kirico/validators/charset_validator_spec.rb
@@ -446,6 +446,10 @@ describe Kirico::CharsetValidator do
         let(:my_field) { nil }
         it { expect(subject).to be_valid }
       end
+      context 'when there exists regex character(s)' do
+        let(:my_field) { '+' }
+        it { expect(subject).not_to be_valid }
+      end
       it_behaves_like 'common'
       it_behaves_like 'numeric'
       it_behaves_like 'latin'


### PR DESCRIPTION
`$` や `+` など正規表現において特別な意味を持つ文字をフィールドに指定した場合に例外となる問題を改修しました。