### PR TITLE
算定基礎届にて 4 月の基礎日数が 31 日となる場合だってある

### DIFF
--- a/lib/kirico/models/data_record22257041.rb
+++ b/lib/kirico/models/data_record22257041.rb
@@ -45,9 +45,9 @@ module Kirico
     validates :old_monthly_standard_income_hel_ins, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9_999_999 }, allow_blank: true
     validates :old_monthly_standard_income_pns_ins, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9_999_999 }, allow_blank: true
     validates :old_applied_at, timeliness: { on_or_after: -> { Date.new(1989, 1, 8) }, type: :date }
-    validates :apr_days, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 30 }
+    validates :apr_days, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 31 }
     validates :may_days, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 31 }
-    validates :jun_days, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 30 }
+    validates :jun_days, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 31 }
     COVERED_MONTHS.each do |month|
       validates "#{month}_income_currency", numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9_999_999 }
       validates "#{month}_income_goods", numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9_999_999 }

--- a/lib/kirico/version.rb
+++ b/lib/kirico/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Kirico
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
例: 末締め、翌10日払いの場合
4/10 に支払われる給与は 3/1-3/31 分の給与
この場合 4 月の基礎日数は 31 日となる