### PR TITLE
sjis_bytesize バリデーションエラー時のメッセージをわかりやすく

### DIFF
--- a/lib/kirico/config/locales/en.yml
+++ b/lib/kirico/config/locales/en.yml
@@ -4,6 +4,16 @@ en:
     messages:
       invalid_charset: "has invalid character(s): %{error_chars}"
       invalid_space_divider: "must be dividied by %{space_type}"
+      too_long_in_bytes:
+        one: is too long (maximum is 1 byte)
+        other: is too long (maximum is %{count} bytes)
+      too_short_in_bytes:
+        one: is too short (minimum is 1 byte)
+        other: is too short (minimum is %{count} bytes)
+      wrong_length_in_bytes:
+        one: is the wrong length (should be 1 byte)
+        other: is the wrong length (should be %{count} bytes)
+      other_than: must be other than %{count}
       invalid_date: "is not a valid date"
       invalid_time: "is not a valid time"
       invalid_datetime: "is not a valid datetime"

--- a/lib/kirico/config/locales/en.yml
+++ b/lib/kirico/config/locales/en.yml
@@ -13,7 +13,6 @@ en:
       wrong_length_in_bytes:
         one: is the wrong length (should be 1 byte)
         other: is the wrong length (should be %{count} bytes)
-      other_than: must be other than %{count}
       invalid_date: "is not a valid date"
       invalid_time: "is not a valid time"
       invalid_datetime: "is not a valid datetime"

--- a/lib/kirico/config/locales/ja.yml
+++ b/lib/kirico/config/locales/ja.yml
@@ -4,9 +4,9 @@ ja:
     messages:
       invalid_charset: "に利用できない文字が入力されています。%{error_chars}"
       invalid_space_divider: "は%{space_type}で区切ってください。"
-      too_long: は%{count}文字以内で入力してください。
-      too_short: は%{count}文字以上で入力してください。
-      wrong_length: は%{count}文字で入力してください。
+      too_long_in_bytes: は%{count}バイト以内で入力してください。
+      too_short_in_bytes: は%{count}バイト以上で入力してください。
+      wrong_length_in_bytes: は%{count}バイトで入力してください。
       invalid_date: "は正しい形式で入力してください。"
       invalid_time: "は正しい形式で入力してください。"
       invalid_datetime: "は正しい形式で入力してください。"

--- a/lib/kirico/validators/sjis_bytesize_validator.rb
+++ b/lib/kirico/validators/sjis_bytesize_validator.rb
@@ -12,7 +12,7 @@ require 'active_model/validator'
 # 参考:  https://github.com/rails/rails/blob/fe1f4b2ad56f010a4e9b93d547d63a15953d9dc2/activemodel/lib/active_model/validations/length.rb
 module Kirico
   class SjisBytesizeValidator < ActiveModel::EachValidator
-    MESSAGES  = { is: :wrong_length, minimum: :too_short, maximum: :too_long }.freeze
+    MESSAGES  = { is: :wrong_length_in_bytes, minimum: :too_short_in_bytes, maximum: :too_long_in_bytes }.freeze
     CHECKS    = { is: :==, minimum: :>=, maximum: :<= }.freeze
 
     RESERVED_OPTIONS = %i(minimum maximum within is too_short too_long)

--- a/lib/kirico/version.rb
+++ b/lib/kirico/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kirico
-  VERSION = '1.0.4'
+  VERSION = '1.0.5'
 end


### PR DESCRIPTION
## やりたいこと

`sjis_bytesize` バリデータは sjis 換算のバイト数を検証する。

例:

```ruby
# first_name は sjis 換算で 4 バイト以上
validates :first_name, charset: { accept: [:all] }, sjis_bytesize: { minimum: 4 }
```

例えば、上記のような定義の場合に `first_name` に「健太郎」などと設定すると
`first_name は 4 文字以内で入力してください。` というバリデーションエラーメッセージが表示される。

「あれ。3 文字で設定してるのに〜 ❓ 」というユーザの混乱を避けるためにも、
適切なエラーメッセージを表示したい。

## やったこと

ActiveModel の `LengthValidator` と共用していたエラーメッセージのキーを変更しました。

- too_long -> too_long_in_bytes
- too_short -> too_short_in_bytes
- wrong_length -> wrong_length_in_bytes

## やらなかったこと

:sushi:

## 確認方法

```ruby
# kirico ディレクトリ直下で bundle exec pry
require 'kirico'

I18n.locale = :ja

rec  = Kirico::FDManagementRecord.new
rec.area_code = '012'
rec.valid? #=> false
rec.errors #=> 略
```
