### PR TITLE
fix broken shoulda matcher spec

### DIFF
--- a/spec/kirico/models/form_spec.rb
+++ b/spec/kirico/models/form_spec.rb
@@ -4,14 +4,39 @@ require 'spec_helper'
 
 describe Kirico::Form, type: :model do
   context 'when the form is for general use' do
-    let(:form) { FactoryBot.build(:form) }
+    let(:form) { FactoryBot.build(:form, fd: fd, company_count: company_count, company: company, records: records) }
+    let(:fd) { FactoryBot.build(:fd_management_record) }
+    let(:company_count) { FactoryBot.build(:company_count) }
+    let(:company) { FactoryBot.build(:company) }
+    let(:records) { FactoryBot.build_list(:data_record22187041, 3) }
 
     describe 'validations' do
       subject { form }
-      it { is_expected.to validate_presence_of(:fd) }
-      it { is_expected.to validate_presence_of(:company_count) }
-      it { is_expected.to validate_presence_of(:company) }
-      it { is_expected.to validate_presence_of(:records) }
+      it { is_expected.to be_valid }
+
+      context 'fd is nil' do
+        let(:fd) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'company_count is nil' do
+        let(:company_count) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'company is nil' do
+        let(:company) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'records is blank' do
+        let(:records) { [] }
+
+        it { is_expected.to be_invalid }
+      end
     end
 
     describe '#validate_children' do
@@ -99,14 +124,39 @@ describe Kirico::Form, type: :model do
   end
 
   context 'when the form is for SR use' do
-    let(:form) { FactoryBot.build(:sr_form) }
+    let(:form) { FactoryBot.build(:sr_form, fd: fd, company_count: company_count, company: company, records: records) }
+    let(:fd) { FactoryBot.build(:sr_fd_management_record) }
+    let(:company_count) { FactoryBot.build(:sr_company_count) }
+    let(:company) { FactoryBot.build(:company) }
+    let(:records) { FactoryBot.build_list(:data_record22187041, 3) }
 
     describe 'validations' do
       subject { form }
-      it { is_expected.to validate_presence_of(:fd) }
-      it { is_expected.to validate_presence_of(:company_count) }
-      it { is_expected.to validate_presence_of(:company) }
-      it { is_expected.to validate_presence_of(:records) }
+      it { is_expected.to be_valid }
+
+      context 'fd is nil' do
+        let(:fd) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'company_count is nil' do
+        let(:company_count) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'company is nil' do
+        let(:company) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'records is blank' do
+        let(:records) { [] }
+
+        it { is_expected.to be_invalid }
+      end
     end
 
     describe '#validate_children' do


### PR DESCRIPTION
## 概要
shoulda-matcherのバージョンアップに伴い、specが落ちるようになったので直しました。

## 原因
shoulda-matcherのver4.1.0で、`lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb`の、`blank_value`メソッドが、`disallowed_values`に変更になりました。

https://github.com/thoughtbot/shoulda-matchers/compare/v4.0.1...v4.1.0?diff=split#diff-bea52ec23e2aa93bc1228ec91f494c18L181

その結果、`""`を`validate_presence_of`のテストに含めるようになり、companyモデル等のinitialize時に、`""`を引数として渡そうとして、ArgumentErrorで落ちるようになりました。

## やったこと
`validate_presence_of`を、shoulda-matcherを使わない形に、書き換えました。