### PR TITLE
様式変更に伴い、社労士媒体管理コードも修正。

### DIFF
--- a/lib/kirico/models/sr_fd_management_record.rb
+++ b/lib/kirico/models/sr_fd_management_record.rb
@@ -12,6 +12,7 @@ module Kirico
     def to_csv
       [
         '',
+        '',
         sr_code,
         fd_seq_number,
         fmt_ymd_created_at,

--- a/spec/kirico/models/form_spec.rb
+++ b/spec/kirico/models/form_spec.rb
@@ -176,7 +176,7 @@ describe Kirico::Form, type: :model do
       let(:result) { form.to_csv.split("\r\n") }
       describe '1st line' do
         subject { result[0].encode('UTF-8') }
-        it { is_expected.to eq ',0007,004,20170227,22223' }
+        it { is_expected.to eq ',,0007,004,20170227,22223' }
       end
       describe '2nd line' do
         subject { result[1].encode('UTF-8') }

--- a/spec/kirico/models/sr_fd_management_record_spec.rb
+++ b/spec/kirico/models/sr_fd_management_record_spec.rb
@@ -7,6 +7,6 @@ describe Kirico::SrFDManagementRecord, type: :model do
 
   describe '#to_csv' do
     subject { record.to_csv.encode('UTF-8') }
-    it { is_expected.to eq ',0007,004,20170227,22223' }
+    it { is_expected.to eq ',,0007,004,20170227,22223' }
   end
 end


### PR DESCRIPTION
平成30年3月からの新様式変更で、社労士媒体管理コードのレコードが仕様変更されたので修正しました。
https://www.nenkin.go.jp/denshibenri/setsumei/20180305.files/01.pdf

## 変更内容
```
旧様式
【予備】，【社会保険労務士コード】，【FD通番】，【作成年月日】，【代表届書コード】
新様式
【予備１】，【予備２】，【社会保険労務士登録番号】，【媒体通番】，【作成年月日】，【代表届書コード】
```