### PR TITLE
社会保険労務士コードの4桁から8桁への変更に伴い修正。

### DIFF
--- a/lib/kirico/models/sr_fd_management_record.rb
+++ b/lib/kirico/models/sr_fd_management_record.rb
@@ -7,7 +7,7 @@ module Kirico
   class SrFDManagementRecord < BaseFDManagementRecord
     attribute :sr_code, String
 
-    validates :sr_code, charset: { accept: [:numeric] }, sjis_bytesize: { is: 4 }
+    validates :sr_code, charset: { accept: [:numeric] }, sjis_bytesize: { is: 8 }
 
     def to_csv
       [

--- a/spec/factories/sr_fd_management_record.rb
+++ b/spec/factories/sr_fd_management_record.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :sr_fd_management_record, class: Kirico::SrFDManagementRecord do
-    sr_code { '0007' }
+    sr_code { '00000007' }
     fd_seq_number { '004' }
     created_at { Date.new(2017, 2, 27) }
   end

--- a/spec/kirico/models/form_spec.rb
+++ b/spec/kirico/models/form_spec.rb
@@ -166,7 +166,7 @@ describe Kirico::Form, type: :model do
         end
         it 'contains some error messages' do
           expect(form.valid?).to be_falsy
-          expect(form.errors.full_messages.count).to eq 1
+          expect(form.errors.full_messages.count).to eq 2
           expect(form.errors.full_messages[0]).to eq 'Fd Sr code has invalid character(s): 生, 卵'
         end
       end
@@ -176,7 +176,7 @@ describe Kirico::Form, type: :model do
       let(:result) { form.to_csv.split("\r\n") }
       describe '1st line' do
         subject { result[0].encode('UTF-8') }
-        it { is_expected.to eq ',,0007,004,20170227,22223' }
+        it { is_expected.to eq ',,00000007,004,20170227,22223' }
       end
       describe '2nd line' do
         subject { result[1].encode('UTF-8') }

--- a/spec/kirico/models/sr_fd_management_record_spec.rb
+++ b/spec/kirico/models/sr_fd_management_record_spec.rb
@@ -7,6 +7,6 @@ describe Kirico::SrFDManagementRecord, type: :model do
 
   describe '#to_csv' do
     subject { record.to_csv.encode('UTF-8') }
-    it { is_expected.to eq ',,0007,004,20170227,22223' }
+    it { is_expected.to eq ',,00000007,004,20170227,22223' }
   end
 end


### PR DESCRIPTION
社会保険労務士コードが4桁から8桁に変更されていたため修正しました。

https://www.nenkin.go.jp/denshibenri/setsumei/20180305.files/01.pdf
```
社会保険労務士登録番号を８文字で設定する
（例）社会保険労務士登録番号が「０００００００７」の
場合「00000007」と設定する
```