### PR TITLE
Catch up with renaming `Naming/UncommunicativeMethodParamName` to `Naming/MethodParameterName`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Style/FrozenStringLiteralComment:
 Style/MutableConstant:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   MinNameLength: 2
 
 Metrics/AbcSize:


### PR DESCRIPTION
# Why?
I happened to fork it, and came accross the Rubocop error.
So, I revised it.

# Error was:
```
Error: The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName`.
(obsolete configuration found in .rubocop.yml, please update it)
```

# See also:
- https://github.com/rubocop-hq/rubocop/commit/3947ce4e913ca1a71f6d7e5effb8042a5f2f9769#diff-3366e6e13a7a00d8b343860e694c13af