### PR TITLE
Remove dependency to `shoulda-matchers` gem

### DIFF
--- a/kirico.gemspec
+++ b/kirico.gemspec
@@ -44,5 +44,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'shoulda-matchers'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'kirico'
 require 'pry'
 require 'csv'
 require 'factory_bot'
-require 'shoulda-matchers'
 
 # データ定義ファイルの配置パスを設定し、定義させる。
 FactoryBot.definition_file_paths = %w[./spec/factories]
@@ -21,18 +20,3 @@ RSpec.configure do |config|
 end
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    # Choose a test framework:
-    with.test_framework :rspec
-    # Choose one or more libraries:
-    with.library :active_record
-    with.library :active_model
-  end
-end
-
-RSpec.configure do |config|
-  config.include(Shoulda::Matchers::ActiveModel, type: :model)
-  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
-end


### PR DESCRIPTION
The test codes seems NOT to be depended on it.
How about removing dependency to `shoulda-matcher` gem?

Ref.
- https://github.com/kufu/kirico/commit/2d04d06897097f4f2572314bb70e023e1b98cb6c#diff-b979c2934ac0b4ba3f08dabfdd1b2299