### PR TITLE
remove max validation and add adjustment method

### DIFF
--- a/lib/kirico/models/data_record2265700.rb
+++ b/lib/kirico/models/data_record2265700.rb
@@ -33,8 +33,8 @@ module Kirico
     validates :ip_name_yomi, charset: { accept: [:katakana] }, sjis_bytesize: { in: 1..25 }, space_divider: { space: :half_width }
     validates :ip_name, charset: { accept: [:all] }, sjis_bytesize: { in: 0..24 }, allow_blank: true, space_divider: { space: :full_width }
     validates :bonus_payment_at, timeliness: { on_or_after: -> { Date.new(1989, 1, 8) }, type: :date }
-    validates :payment_in_currency, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9_999_999 }
-    validates :payment_in_goods, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9_999_999 }
+    validates :payment_in_currency, numericality: { greater_than_or_equal_to: 0 }
+    validates :payment_in_goods, numericality: { greater_than_or_equal_to: 0 }
     validates :my_number, charset: { accept: [:numeric] }, sjis_bytesize: { is: 12 }, allow_nil: true
     validates :area_code_of_basic_pension_number, charset: { accept: [:numeric] }, sjis_bytesize: { is: 4 }, allow_nil: true
     validates :serial_number_of_basic_pension_number, charset: { accept: [:numeric] }, sjis_bytesize: { is: 6 }, allow_nil: true
@@ -77,6 +77,14 @@ module Kirico
     def bonus_total(currency, goods)
       total = currency.to_i + goods.to_i
       total < 10_000_000 ? total.floor(-3) : 9_999_999
+    end
+
+    def adjusted_payment_in_currency
+      payment_in_currency < 10_000_000 ? payment_in_currency : 9_999_999
+    end
+
+    def adjusted_payment_in_goods
+      payment_in_goods < 10_000_000 ? payment_in_goods : 9_999_999
     end
 
     private

--- a/spec/kirico/models/data_record2265700_spec.rb
+++ b/spec/kirico/models/data_record2265700_spec.rb
@@ -8,6 +8,7 @@ describe Kirico::DataRecord2265700, type: :model do
     subject { FactoryBot.build(:data_record2265700).valid? }
     it { is_expected.to be_truthy }
   end
+
   describe '#bonus_total' do
     let(:rec) { FactoryBot.build(:data_record2265700) }
     subject { rec.bonus_total(currency, goods) }
@@ -54,5 +55,39 @@ describe Kirico::DataRecord2265700, type: :model do
       is_expected.to eq '2265700,21,14,ｸﾄﾜ,000002,ﾖｼﾀﾞ ﾀﾛｳ,吉田　太郎,5,590527,9,010901,' \
         '444444,555555,999000,012345678901,0123,123456,,,,'
     }
+  end
+
+  describe '#adjusted_payment_in_currency' do
+    subject { data_record.adjusted_payment_in_currency }
+    let(:data_record) { FactoryBot.build(:data_record2265700, payment_in_currency: payment_in_currency) }
+
+    context 'payment_in_currency is less than or equal to 9_999_999' do
+      let(:payment_in_currency) { 9_999_998 }
+
+      it { is_expected.to eq 9_999_998 }
+    end
+
+    context 'payment_in_currency is more than 9_999_999' do
+      let(:payment_in_currency) { 15_000_000 }
+
+      it { is_expected.to eq 9_999_999 }
+    end
+  end
+
+  describe '#adjusted_payment_in_goods' do
+    subject { data_record.adjusted_payment_in_goods }
+    let(:data_record) { FactoryBot.build(:data_record2265700, payment_in_goods: payment_in_goods) }
+
+    context 'payment_in_goods is less than or equal to 9_999_999' do
+      let(:payment_in_goods) { 9_999_998 }
+
+      it { is_expected.to eq 9_999_998 }
+    end
+
+    context 'payment_in_goods is more than 9_999_999' do
+      let(:payment_in_goods) { 15_000_000 }
+
+      it { is_expected.to eq 9_999_999 }
+    end
   end
 end


### PR DESCRIPTION
Max validations of `payment_in_currency` and `payment_in_goods` are not needed, because it is possible for them to be more than `9_999_999`.

Therefore, I removed them and added adjustment method of them.