### PR TITLE
算定基礎届の総計が7桁を超える場合`9999999`に丸める

### DIFF
--- a/lib/kirico/models/data_record2225700.rb
+++ b/lib/kirico/models/data_record2225700.rb
@@ -131,7 +131,7 @@ module Kirico
         income_total(apr_income_currency, apr_income_goods).to_s.rjust(7, '0'),
         income_total(may_income_currency, may_income_goods).to_s.rjust(7, '0'),
         income_total(jun_income_currency, jun_income_goods).to_s.rjust(7, '0'),
-        income_all_total.to_s.rjust(7, '0'),
+        income_all_total_with_round.to_s.rjust(7, '0'),
         income_average.to_s.rjust(7, '0'),
         avg_adjustment.nil? ? nil : avg_adjustment.to_s.rjust(7, '0'),
         my_number,
@@ -165,6 +165,13 @@ module Kirico
       target_months.map do |month|
         send("#{month}_income_currency").to_i + send("#{month}_income_goods").to_i
       end.inject(:+)
+    end
+
+    # 総計を計算する
+    # CSVへ出力する際、10,000,000 円以上は 9,999,999 を返す
+    def income_all_total_with_round
+      total = income_all_total
+      total < 10_000_000 ? total : 9_999_999
     end
 
     # 平均額を計算する

--- a/spec/kirico/models/data_record2225700_spec.rb
+++ b/spec/kirico/models/data_record2225700_spec.rb
@@ -149,13 +149,13 @@ describe Kirico::DataRecord2225700, type: :model do
     before do
       allow(rec).to receive(:target_months).and_return(%i[apr may jun])
     end
-    context 'not round' do
+    context 'when income_all_total is 9_999_999 or less' do
       let(:apr_income_currency) { 100 }
       let(:may_income_currency) { 200 }
       let(:jun_income_currency) { 300 }
       it { is_expected.to eq 600 }
     end
-    context 'round' do
+    context 'when income_all_total is more than 9_999_999' do
       let(:apr_income_currency) { 10_000_000 }
       let(:may_income_currency) { 0 }
       let(:jun_income_currency) { 0 }

--- a/spec/kirico/models/data_record2225700_spec.rb
+++ b/spec/kirico/models/data_record2225700_spec.rb
@@ -133,6 +133,36 @@ describe Kirico::DataRecord2225700, type: :model do
     end
   end
 
+  describe '#income_all_total_with_round' do
+    let(:rec) {
+      FactoryBot.build(
+        :data_record2225700,
+        apr_income_currency: apr_income_currency,
+        may_income_currency: may_income_currency,
+        jun_income_currency: jun_income_currency,
+        apr_income_goods: 0,
+        may_income_goods: 0,
+        jun_income_goods: 0
+      )
+    }
+    subject { rec.income_all_total_with_round }
+    before do
+      allow(rec).to receive(:target_months).and_return(%i[apr may jun])
+    end
+    context 'not round' do
+      let(:apr_income_currency) { 100 }
+      let(:may_income_currency) { 200 }
+      let(:jun_income_currency) { 300 }
+      it { is_expected.to eq 600 }
+    end
+    context 'round' do
+      let(:apr_income_currency) { 10_000_000 }
+      let(:may_income_currency) { 0 }
+      let(:jun_income_currency) { 0 }
+      it { is_expected.to eq 9_999_999 }
+    end
+  end
+
   describe '#income_average' do
     let(:rec) {
       FactoryBot.build(


### PR DESCRIPTION
https://www.nenkin.go.jp/denshibenri/oshirase/zenpan/20190820.files/14.pdf
該当は項目36の総計欄です。
項目37の平均と同じように7桁へ丸める処理を追加しています。