### PR TITLE
算定基礎届の被保険者整理番号は70歳以上の場合は未入力を受け付ける。

### DIFF
--- a/lib/kirico/models/data_record2225700.rb
+++ b/lib/kirico/models/data_record2225700.rb
@@ -52,7 +52,8 @@ module Kirico
     validates :prefecture_code, charset: { accept: [:numeric] }, sjis_bytesize: { is: 2 }
     validates :area_code, charset: { accept: [:numeric] }, sjis_bytesize: { is: 2 }
     validates :office_code, charset: { accept: %i[numeric latin katakana] }, sjis_bytesize: { in: 1..4 }
-    validates :ip_code, charset: { accept: [:numeric] }, sjis_bytesize: { in: 1..6 }
+    validates :ip_code, charset: { accept: [:numeric] }, sjis_bytesize: { in: 1..6 }, allow_blank: true
+    validates :ip_code, presence: true, if: proc { |record| record.seventy_years_and_over.nil? }
     validates :ip_name_yomi, charset: { accept: [:katakana] }, sjis_bytesize: { in: 1..25 }, space_divider: { space: :half_width }
     validates :ip_name, charset: { accept: [:all] }, sjis_bytesize: { in: 0..24 }, allow_blank: true, space_divider: { space: :full_width }
     validates :applied_at, timeliness: { on_or_after: -> { Date.new(1989, 1, 8) }, type: :date }

--- a/spec/kirico/models/data_record2225700_spec.rb
+++ b/spec/kirico/models/data_record2225700_spec.rb
@@ -8,6 +8,31 @@ describe Kirico::DataRecord2225700, type: :model do
     subject { FactoryBot.build(:data_record2225700).valid? }
     it { is_expected.to be_truthy }
   end
+
+  describe 'over 70 valid factory' do
+    subject { FactoryBot.build(:data_record2225700, ip_code: nil, seventy_years_and_over: 1).valid? }
+    it { is_expected.to be_truthy }
+  end
+
+  describe 'no my_number over 70 valid factory' do
+    subject { FactoryBot.build(:data_record2225700, ip_code: nil, my_number: nil, seventy_years_and_over: 1).valid? }
+    it { is_expected.to be_truthy }
+  end
+
+  describe 'over 70 invalid factory' do
+    subject {
+      FactoryBot.build(
+        :data_record2225700,
+        ip_code: nil,
+        my_number: nil,
+        area_code_of_basic_pension_number: nil,
+        serial_number_of_basic_pension_number: nil,
+        seventy_years_and_over: 1
+      ).valid?
+    }
+    it { is_expected.to be_falsey }
+  end
+
   describe '#income_total' do
     let(:rec) { FactoryBot.build(:data_record2225700) }
     subject { rec.income_total(currency, goods) }


### PR DESCRIPTION
https://www.nenkin.go.jp/denshibenri/program/download.files/specs1201.pdf
↑の134p「被保険者整理番号」の注釈より、

> ※「70歳以上被用者届のみ提出」に「1」を設定した場合は、省略する

とあるので、70歳以上被扶養者届の場合は未入力を受け付けるようにしました。