### PR TITLE
賞与支払届の賞与額合計は下3桁を常に0にする

### DIFF
--- a/lib/kirico/models/data_record2265700.rb
+++ b/lib/kirico/models/data_record2265700.rb
@@ -76,7 +76,7 @@ module Kirico
 
     def bonus_total(currency, goods)
       total = currency.to_i + goods.to_i
-      total < 10_000_000 ? total.floor(-3) : 9_999_999
+      total >= 10_000_000 ? 9_999_000 : total.floor(-3)
     end
 
     def adjusted_payment_in_currency

--- a/spec/kirico/models/data_record2265700_spec.rb
+++ b/spec/kirico/models/data_record2265700_spec.rb
@@ -45,7 +45,7 @@ describe Kirico::DataRecord2265700, type: :model do
     context 'when the total is 10,000,000' do
       let(:currency) { 9_999_999 }
       let(:goods) { 1 }
-      it { is_expected.to eq 9_999_999 }
+      it { is_expected.to eq 9_999_000 }
     end
   end
 
@@ -61,7 +61,7 @@ describe Kirico::DataRecord2265700, type: :model do
       let(:data_record) { FactoryBot.build(:data_record2265700, payment_in_currency: 10_000_000, payment_in_goods: 10_000_000) }
       it {
         is_expected.to eq '2265700,21,14,ｸﾄﾜ,000002,ﾖｼﾀﾞ ﾀﾛｳ,吉田　太郎,5,590527,9,010901,' \
-          '9999999,9999999,9999999,012345678901,0123,123456,,,,'
+          '9999999,9999999,9999000,012345678901,0123,123456,,,,'
       }
     end
   end


### PR DESCRIPTION
賞与支払届の賞与額合計について、年金事務所に問い合わせたところ下三桁はゼロにするのが正しいとのことでした。