### PR TITLE
Ruby 3系のキーワード引数非互換に備える

### DIFF
--- a/lib/kirico/validators/sjis_bytesize_validator.rb
+++ b/lib/kirico/validators/sjis_bytesize_validator.rb
@@ -59,7 +59,7 @@ module Kirico
         default_message = options[MESSAGES[key]]
         errors_options[:message] ||= default_message if default_message
 
-        record.errors.add(attribute, MESSAGES[key], errors_options)
+        record.errors.add(attribute, MESSAGES[key], **errors_options)
       end
     end
 


### PR DESCRIPTION
以下のPRでrspecが失敗しており、失敗しないための事前の修正です。
https://github.com/kufu/kirico/pull/88

失敗の原因はRuby 3.0でHashからキーワード引数への変換が非互換になったのが原因のようでした。
https://www.ruby-lang.org/ja/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
そのため、double splat演算子（**）での対応をしました。

この修正を行っておけば、失敗していたPR(#88)もRuby2.7/3.0/3.1でrspecが通ることも事前に確認しました。