### PR TITLE
Add git to system dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
       - run:
           name: Install System Dependencies
           # https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
-          command: apt-get update -y && apt-get install -y ssh
+          command: apt-get update -y && apt-get install -y git ssh
   bundle_gems:
     description: "Bundle gems"
     steps:


### PR DESCRIPTION
See also https://github.com/kufu/kirico/pull/91

gitがインストールされておらず、Ruby 3.1のイメージでのCIが失敗しているようです。
https://app.circleci.com/pipelines/github/kufu/kirico/56/workflows/73cda8fc-37f8-4152-a176-d1486a412e5c/jobs/291

おそらく、この変更によってrubylang/rubyからgitが取り除かれたのが原因のようなので、明示的にインストールするようにします。
https://github.com/ruby/ruby-docker-images/pull/45