### PR TITLE
Use rubylang/ruby:*-dev images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,19 @@ version: 2.1
 executors:
   ruby_3_1:
     docker:
-      - image: rubylang/ruby:3.1-focal
+      - image: rubylang/ruby:3.1-dev-focal
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
   ruby_3_0:
     docker:
-      - image: rubylang/ruby:3.0.0-focal
+      - image: rubylang/ruby:3.0-dev-focal
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
   ruby_2_7:
     docker:
-      - image: rubylang/ruby:2.7.3-bionic
+      - image: rubylang/ruby:2.7-dev-bionic
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN


### PR DESCRIPTION
See also https://github.com/kufu/kirico/pull/91

> This repository consists of two kinds of images. One is for production use, and the other is for development. An image for development is based on the image for production of the same ruby and ubuntu versions and installed development tools such as build-essential and gdb, in addition. It has -dev suffix after the version number, like rubylang/ruby:3.2.0-dev-jammy.

https://hub.docker.com/r/rubylang/ruby