### PR TITLE
fix uninitialized constant error.

### DIFF
--- a/lib/kirico/validators/charset_validator.rb
+++ b/lib/kirico/validators/charset_validator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_model'
-require 'active_model/validator'
 
 # 文字種別を検証する
 #

--- a/lib/kirico/validators/sjis_bytesize_validator.rb
+++ b/lib/kirico/validators/sjis_bytesize_validator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_model'
-require 'active_model/validator'
 
 # SJIS 換算の文字長を検証する
 # SJIS 変換不可文字が設定された場合は 1 文字としてカウントする

--- a/lib/kirico/validators/space_divider_validator.rb
+++ b/lib/kirico/validators/space_divider_validator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_model'
-require 'active_model/validator'
-require 'active_model/validations/format'
 
 # 文字種別を検証する
 #


### PR DESCRIPTION
Changed to load files under `ActiveModel` via autoload

```
.../lib/active_model/validations/clusivity.rb:9:in `<module:Clusivity>': uninitialized constant ActiveModel::Validations::Clusivity::ResolveValue (NameError)

      include ResolveValue
```